### PR TITLE
FIX si no habia encabezados, mostrar bien las notas

### DIFF
--- a/app/dashboard/hoteles/_components/hotel-dialog.tsx
+++ b/app/dashboard/hoteles/_components/hotel-dialog.tsx
@@ -279,9 +279,12 @@ interface DeleteTarifaPreferencialProps {
   id_tarifa_preferencial_sencilla?: number | null;
   id_tarifa_preferencial_doble?: number | null;
 }
+
+
 export function quitarAcentos(texto) {
   return texto.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
 }
+
 
 const estadosMX = [
   "AGUASCALIENTES",
@@ -610,13 +613,18 @@ export function HotelDialog({
       const rawComentarios = hotel.Comentarios || "";
 
 // Validamos si hay al menos un encabezado presente
-const tieneEncabezados = /##\s+[A-Z\s]+?\s+##/.test(rawComentarios);
+const tieneEncabezados = /##\s+[A-ZÁÉÍÓÚÑ\s]+?\s+##/.test(rawComentarios);
 
-// Si tiene encabezados, solo extraemos 'NOTAS GENERALES'
-// Si no hay ningún encabezado, asumimos que todo el texto previo es una nota general heredada
+// Verificamos si existe una sección explícita de 'NOTAS GENERALES'
+const tieneNotasGenerales = /##\s*NOTAS GENERALES\s*##/.test(rawComentarios);
+
+// Si tiene encabezados y hay sección de notas generales, extraerla
+// Si no tiene encabezados, es un comentario antiguo → usar todo
+// Si tiene encabezados pero no tiene 'NOTAS GENERALES', no mostrar nada
 const notasGenerales = tieneEncabezados
-  ? extractNotesSection(rawComentarios, "NOTAS GENERALES")
+  ? (tieneNotasGenerales ? extractNotesSection(rawComentarios, "NOTAS GENERALES") : "")
   : rawComentarios;
+
 
 
       setFormData({


### PR DESCRIPTION
Se actualizó la lógica de visualización de la sección "Notas Generales" en el modal de detalle de hotel. Anteriormente, en registros antiguos sin estructura de encabezados, el contenido completo del campo Comentarios se mostraba en dicha sección. Sin embargo, esto causaba una duplicación o visualización incorrecta cuando existían encabezados de otras secciones pero no el de "Notas Generales". Con esta mejora, ahora se detecta explícitamente si existe el encabezado ## NOTAS GENERALES ##. Solo en ese caso se mostrará su contenido. Si no existen encabezados en absoluto, se asume que es una nota heredada antigua y se muestra completa; de lo contrario, no se muestra nada. Esto garantiza una visualización coherente entre registros nuevos y antiguos.